### PR TITLE
Fixing linux build by removing win32-isms

### DIFF
--- a/examples/cpp/Example_2_3_Display.cpp
+++ b/examples/cpp/Example_2_3_Display.cpp
@@ -1,11 +1,11 @@
 #include "Common.h"
 
-class Display : public GlfwApp {
+class RiftDisplay : public GlfwApp {
 glm::uvec2 eyeSize;
 ovrHmd hmd;
 
 public:
-Display() {
+RiftDisplay() {
   hmd = ovrHmd_Create(0);
   if (!hmd) {
     FAIL("Unable to detect Rift display");
@@ -55,4 +55,4 @@ void draw() {
 }
 };
 
-RUN_OVR_APP(Display);
+RUN_OVR_APP(RiftDisplay);

--- a/examples/cpp/Example_4_3_1_Distorted.cpp
+++ b/examples/cpp/Example_4_3_1_Distorted.cpp
@@ -29,13 +29,13 @@ public:
       ovrTextureHeader & eyeTextureHeader = eyeTextures[eye].Header;
       memset(eyeTextures + eye, 0, sizeof(eyeTextures[eye]));
         eyeFovPorts[eye] = hmdDesc.DefaultEyeFov[eye];
-      eyeTextureHeader.TextureSize = 
+      eyeTextureHeader.TextureSize =
         ovrHmd_GetFovTextureSize(hmd, eye, hmdDesc.DefaultEyeFov[eye], 1.0f);
       eyeTextureHeader.RenderViewport.Size = eyeTextureHeader.TextureSize;
       eyeTextureHeader.RenderViewport.Pos.x = 0;
       eyeTextureHeader.RenderViewport.Pos.y = 0;
       eyeTextureHeader.API = ovrRenderAPI_OpenGL;
-      sceneTextures[eye] = 
+      sceneTextures[eye] =
         GlUtils::getImageAsTexture(SCENE_IMAGES[eye]);
       ((ovrGLTextureData&)eyeTextures[eye]).TexId =
         sceneTextures[eye]->texture;
@@ -46,10 +46,10 @@ public:
     cfg.Header.RTSize = hmdDesc.Resolution;
     cfg.Header.Multisample = 1;
 
-    int distortionCaps = ovrDistortionCap_Chromatic 
+    int distortionCaps = ovrDistortionCap_Chromatic
       | ovrDistortionCap_TimeWarp
       | ovrDistortionCap_NoSwapBuffers;
-    int configResult = ovrHmd_ConfigureRendering(hmd, &cfg, 
+    int configResult = ovrHmd_ConfigureRendering(hmd, &cfg,
       distortionCaps, eyeFovPorts, eyeRenderDescs);
     if (0 == configResult) {
       FAIL("Unable to configure rendering");
@@ -62,7 +62,6 @@ public:
     glClear(GL_COLOR_BUFFER_BIT);
     for_each_eye([&](ovrEyeType eye) {
       ovrPosef renderPose = ovrHmd_BeginEyeRender(hmd, eye);
-      Sleep(9);
       ovrHmd_EndEyeRender(hmd, eye, renderPose, &eyeTextures[eye]);
     });
     glDisable(GL_CULL_FACE);

--- a/examples/cpp/common/Interaction.cpp
+++ b/examples/cpp/common/Interaction.cpp
@@ -246,8 +246,8 @@ void CameraControl::applyInteraction(glm::mat4 & camera) {
     recompose(camera);
   }
 
-  static DWORD lastKeyboardUpdateTick = 0;
-  DWORD now = GetTickCount();
+  static uint32_t lastKeyboardUpdateTick = 0;
+  uint32_t now = Platform::elapsedMillis();
   if (0 != lastKeyboardUpdateTick) {
     float dt = (now - lastKeyboardUpdateTick) / 1000.0f;
     if (keyboardRotate.x || keyboardRotate.y || keyboardRotate.z) {


### PR DESCRIPTION
'Display' is a typedef in Linux, so it can't be used to name an example class.  Sleep(), DWORD and GetTickCount() are all win32 specific, so they have to be replaced or removed.
