### PR TITLE
Remove old 0.3.1 workaround code

### DIFF
--- a/examples/cpp/Example_4_3_1_Distorted.cpp
+++ b/examples/cpp/Example_4_3_1_Distorted.cpp
@@ -63,11 +63,7 @@ public:
       ovrPosef renderPose = ovrHmd_BeginEyeRender(hmd, eye);
       ovrHmd_EndEyeRender(hmd, eye, renderPose, &eyeTextures[eye]);
     });
-    glDisable(GL_CULL_FACE);
-    glDisable(GL_DEPTH_TEST);
     ovrHmd_EndFrame(hmd);
-    glEnable(GL_CULL_FACE);
-    glEnable(GL_DEPTH_TEST);
   }
 };
 


### PR DESCRIPTION
Slight git confusion: why is it showing me the whitespace changes again?
