### PR TITLE
Realized that we didn't need these, because I put the same tweak into my OvrUtils refactor.

### DIFF
--- a/examples/cpp/Example_4_2_DisplayTargeting.cpp
+++ b/examples/cpp/Example_4_2_DisplayTargeting.cpp
@@ -7,14 +7,6 @@ public:
 
   void draw() {
 
-    // A bug in some versions of the SDK (0.4.x) prevents Direct Mode from 
-    // engaging properly unless you call the GetEyePoses function.
-    {
-      static ovrVector3f offsets[2];
-      static ovrPosef poses[2];
-      ovrHmd_GetEyePoses(hmd, 0, offsets, poses, nullptr);
-    }
-
     glm::uvec2 eyeSize(hmd->Resolution.w / 2, hmd->Resolution.h);
     glm::ivec2 position = glm::ivec2(0, 0);
     glm::vec4 color = glm::vec4(1, 0, 0, 1);
@@ -45,4 +37,8 @@ public:
   Fullscreen() : DisplayTargetingExample(true) {}
 };
 
+/**
+ * Set this to Windowed for a windowed app.
+ * Set this to Fullscreen for a fullscreen app.
+ */
 RUN_OVR_APP(Windowed);

--- a/examples/cpp/Example_4_3_0_Undistorted.cpp
+++ b/examples/cpp/Example_4_3_0_Undistorted.cpp
@@ -59,12 +59,7 @@ public:
 
   void draw() {
     using namespace oglplus;
-    // A bug in some versions of the SDK prevents Direct Mode from engaging properly unless you call the GetEyePoses function
-    {
-      static ovrPosef eyePoses[2];
-      static ovrVector3f eyeOffsets[2];
-      ovrHmd_GetEyePoses(hmd, getFrame(), eyeOffsets, eyePoses, nullptr);
-    }
+
     DefaultFramebuffer().Bind(Framebuffer::Target::Draw);
     Context::Clear().ColorBuffer();
     for_each_eye([&](ovrEyeType eye) {

--- a/examples/cpp/Example_4_3_0_Undistorted.cpp
+++ b/examples/cpp/Example_4_3_0_Undistorted.cpp
@@ -56,7 +56,6 @@ public:
     RiftGlfwApp::shutdownGl();
   }
 
-
   void draw() {
     using namespace oglplus;
 

--- a/examples/cpp/Example_4_3_1_Distorted.cpp
+++ b/examples/cpp/Example_4_3_1_Distorted.cpp
@@ -72,12 +72,6 @@ public:
   }
 
   void draw() {
-    static ovrPosef eyePoses[2];
-    // A bug in some versions of the SDK prevents Direct Mode from engaging properly unless you call the GetEyePoses function
-    {
-      static ovrVector3f eyeOffsets[2];
-      ovrHmd_GetEyePoses(hmd, getFrame(), eyeOffsets, eyePoses, nullptr);
-    }
     ovrHmd_BeginFrame(hmd, getFrame());
     ovrHmd_EndFrame(hmd, eyePoses, eyeTextures);
   }

--- a/examples/cpp/Example_4_3_1_Distorted.cpp
+++ b/examples/cpp/Example_4_3_1_Distorted.cpp
@@ -57,7 +57,7 @@ public:
 
     ovrEyeRenderDesc eyeRenderDescs[2];
     int configResult = ovrHmd_ConfigureRendering(hmd, &config,
-      distortionCaps, hmd->DefaultEyeFov, eyeRenderDescs);
+        distortionCaps, hmd->DefaultEyeFov, eyeRenderDescs);
     if (0 == configResult) {
       FAIL("Unable to configure rendering");
     }

--- a/examples/cpp/Example_4_3_1_Distorted.cpp
+++ b/examples/cpp/Example_4_3_1_Distorted.cpp
@@ -29,20 +29,15 @@ public:
       glm::uvec2 textureSize;
       sceneTextures[eye] = oria::load2dTexture(sceneImages[eye], textureSize);
 
-      memset(eyeTextures + eye, 0,
-        sizeof(eyeTextures[eye]));
+      memset(eyeTextures + eye, 0, sizeof(eyeTextures[eye]));
 
-      ovrTextureHeader & eyeTextureHeader =
-        eyeTextures[eye].Header;
+      ovrTextureHeader & eyeTextureHeader = eyeTextures[eye].Header;
 
       eyeTextureHeader.TextureSize = ovr::fromGlm(textureSize);
-      eyeTextureHeader.RenderViewport.Size =
-        eyeTextureHeader.TextureSize;
-
+      eyeTextureHeader.RenderViewport.Size = eyeTextureHeader.TextureSize;
       eyeTextureHeader.API = ovrRenderAPI_OpenGL;
 
-      ((ovrGLTextureData&)eyeTextures[eye]).TexId =
-        oglplus::GetName(*sceneTextures[eye]);
+      ((ovrGLTextureData&)eyeTextures[eye]).TexId = oglplus::GetName(*sceneTextures[eye]);
     });
 
     ovrRenderAPIConfig config;
@@ -57,8 +52,8 @@ public:
 #endif
 
     int distortionCaps = 
-      ovrDistortionCap_Vignette
-      | ovrDistortionCap_Chromatic;
+        ovrDistortionCap_Vignette
+        | ovrDistortionCap_Chromatic;
 
     ovrEyeRenderDesc eyeRenderDescs[2];
     int configResult = ovrHmd_ConfigureRendering(hmd, &config,
@@ -72,6 +67,7 @@ public:
   }
 
   void draw() {
+    static ovrPosef eyePoses[2];
     ovrHmd_BeginFrame(hmd, getFrame());
     ovrHmd_EndFrame(hmd, eyePoses, eyeTextures);
   }

--- a/examples/cpp/Example_4_3_1_Distorted.cpp
+++ b/examples/cpp/Example_4_3_1_Distorted.cpp
@@ -30,9 +30,7 @@ public:
       sceneTextures[eye] = oria::load2dTexture(sceneImages[eye], textureSize);
 
       memset(eyeTextures + eye, 0, sizeof(eyeTextures[eye]));
-
       ovrTextureHeader & eyeTextureHeader = eyeTextures[eye].Header;
-
       eyeTextureHeader.TextureSize = ovr::fromGlm(textureSize);
       eyeTextureHeader.RenderViewport.Size = eyeTextureHeader.TextureSize;
       eyeTextureHeader.API = ovrRenderAPI_OpenGL;


### PR DESCRIPTION
Note: no whitespace was harmed in the making of this pull request.